### PR TITLE
Add PostgreSQL command-line helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,112 @@
-# script1488
+# pgtool
+
+Инструмент командной строки, упрощающий повседневную работу с PostgreSQL. Утилита позволяет выполнять запросы, просматривать структуру базы, выгружать данные и запускать SQL-скрипты из терминала.
+
+## Возможности
+
+- Подключение к PostgreSQL через DSN либо указание хоста, порта, пользователя и базы данных.
+- Загрузка настроек из конфигурационного файла `pgtool.toml` или переменных окружения с префиксом `PGTOOL_`.
+- Выполнение одиночных запросов и SQL-файлов с параметрами.
+- Просмотр списка таблиц и структуры конкретной таблицы.
+- Экспорт результатов запроса в CSV.
+
+## Установка
+
+```bash
+pip install --editable .
+```
+
+После установки будет доступна команда `pgtool`.
+
+## Настройка подключения
+
+Подключение можно задавать через параметры командной строки, конфигурационный файл или переменные окружения. Приоритет следующий: аргументы CLI → переменные окружения → конфигурационный файл.
+
+### Пример `pgtool.toml`
+
+```toml
+[database]
+host = "localhost"
+port = 5432
+user = "postgres"
+password = "postgres"
+database = "example"
+```
+
+Файл можно разместить в одном из путей:
+
+- `./pgtool.toml` (текущая директория)
+- `~/.pgtool.toml`
+- `~/.config/pgtool/config.toml`
+
+Явный путь можно указать через `--config`.
+
+### Переменные окружения
+
+Переменные имеют префикс `PGTOOL_`, например:
+
+```bash
+export PGTOOL_HOST=localhost
+export PGTOOL_PORT=5432
+export PGTOOL_USER=postgres
+```
+
+Доступны переменные `HOST`, `PORT`, `USER`, `PASSWORD`, `DATABASE`, `DSN` и дополнительные параметры `OPTION_*`.
+
+## Использование
+
+Получить справку по командам:
+
+```bash
+pgtool --help
+```
+
+### Выполнить запрос
+
+```bash
+pgtool --host localhost --database example --user postgres query "SELECT now()"
+```
+
+### Выполнить запрос из файла
+
+```bash
+pgtool --dsn postgresql://postgres:postgres@localhost/example query --file query.sql
+```
+
+### Выполнить запрос без получения результата
+
+```bash
+pgtool query "UPDATE users SET active = true WHERE id = %s" --params 42 --no-fetch
+```
+
+### Просмотреть таблицы
+
+```bash
+pgtool tables
+```
+
+### Описание таблицы
+
+```bash
+pgtool describe public.users
+```
+
+### Экспорт в CSV
+
+```bash
+pgtool export --output users.csv "SELECT * FROM users LIMIT 100"
+```
+
+### Выполнение SQL-скрипта
+
+```bash
+pgtool script migrations/init.sql
+```
+
+## Разработка
+
+- Исходный код расположен в каталоге `pgtool/`.
+- CLI определяется в `pgtool/cli.py`.
+- Настройки подключения реализованы в `pgtool/config.py`.
+
+Для запуска линтеров или тестов можно добавить собственные сценарии. В текущей версии автоматические проверки отсутствуют.

--- a/pgtool/__init__.py
+++ b/pgtool/__init__.py
@@ -1,0 +1,4 @@
+"""Utilities for comfortable PostgreSQL workflows."""
+
+from .config import DatabaseConfig, load_config  # noqa: F401
+from .db import DatabaseConnection  # noqa: F401

--- a/pgtool/cli.py
+++ b/pgtool/cli.py
@@ -1,0 +1,194 @@
+"""Command line interface for pgtool."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, List, Sequence
+import ast
+
+from .config import DatabaseConfig, load_config, merge_configs
+from .db import DatabaseConnection
+from .render import format_table
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Утилита для удобной работы с PostgreSQL",
+    )
+
+    parser.add_argument("--config", help="Путь до TOML файла конфигурации", default=None)
+    parser.add_argument("--dsn", help="Строка подключения" , default=None)
+    parser.add_argument("--host", help="Хост PostgreSQL", default=None)
+    parser.add_argument("--port", type=int, help="Порт PostgreSQL", default=None)
+    parser.add_argument("--user", help="Пользователь", default=None)
+    parser.add_argument("--password", help="Пароль", default=None)
+    parser.add_argument("--database", help="База данных", default=None)
+    parser.add_argument(
+        "--option",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Дополнительные параметры подключения",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    query_parser = subparsers.add_parser("query", help="Выполнить SQL запрос")
+    query_parser.add_argument("sql", nargs="?", help="SQL выражение для выполнения")
+    query_parser.add_argument("--file", "-f", help="Путь до SQL файла")
+    query_parser.add_argument(
+        "--no-fetch",
+        action="store_true",
+        help="Не возвращать результаты (для INSERT/UPDATE/DELETE)",
+    )
+    query_parser.add_argument(
+        "--params",
+        nargs="*",
+        default=[],
+        metavar="VALUE",
+        help="Параметры запроса (позиционные)",
+    )
+
+    tables_parser = subparsers.add_parser("tables", help="Показать список таблиц")
+    tables_parser.add_argument(
+        "--include-system",
+        action="store_true",
+        help="Отображать системные схемы",
+    )
+
+    describe_parser = subparsers.add_parser("describe", help="Описание таблицы")
+    describe_parser.add_argument("table", help="Имя таблицы, можно schema.table")
+
+    export_parser = subparsers.add_parser("export", help="Выгрузить результат запроса в CSV")
+    export_parser.add_argument("--output", "-o", required=True, help="Путь до CSV файла")
+    export_parser.add_argument("sql", nargs="?", help="SQL выражение")
+    export_parser.add_argument("--file", "-f", help="Путь до SQL файла")
+    export_parser.add_argument(
+        "--params",
+        nargs="*",
+        default=[],
+        metavar="VALUE",
+        help="Параметры запроса (позиционные)",
+    )
+
+    script_parser = subparsers.add_parser("script", help="Выполнить SQL скрипт")
+    script_parser.add_argument("path", help="Файл SQL со множеством выражений")
+
+    return parser
+
+
+def parse_options(options: Iterable[str]) -> dict:
+    parsed = {}
+    for option in options:
+        if "=" not in option:
+            raise ValueError(f"Параметр опции должен быть в формате KEY=VALUE, получено: {option}")
+        key, value = option.split("=", 1)
+        parsed[key.strip()] = value.strip()
+    return parsed
+
+
+def parse_params(params: Sequence[str]) -> List[object]:
+    parsed: List[object] = []
+    for param in params:
+        try:
+            parsed.append(ast.literal_eval(param))
+        except (ValueError, SyntaxError):
+            parsed.append(param)
+    return parsed
+
+
+def read_sql(sql: str | None, file_path: str | None) -> str:
+    if sql and file_path:
+        raise ValueError("Нельзя одновременно передать SQL и путь до файла")
+    if sql:
+        return sql
+    if file_path:
+        return Path(file_path).read_text(encoding="utf-8")
+    raise ValueError("Нужно передать SQL выражение либо путь до файла")
+
+
+def build_config(args: argparse.Namespace) -> DatabaseConfig:
+    file_config = load_config(args.config)
+    env_config = DatabaseConfig.from_environment()
+
+    mapping = {key: getattr(args, key) for key in ("host", "port", "user", "password", "database", "dsn")}
+    option_mapping = parse_options(args.option)
+    mapping["options"] = option_mapping
+    cli_config = DatabaseConfig.from_mapping(mapping)
+
+    return merge_configs((file_config, env_config, cli_config))
+
+
+def handle_query(db: DatabaseConnection, args: argparse.Namespace) -> None:
+    sql = read_sql(args.sql, args.file)
+    params = parse_params(args.params)
+    columns, rows = db.run_query(sql, params=params, fetch=not args.no_fetch)
+    if args.no_fetch:
+        print("Запрос выполнен успешно, результаты не возвращены")
+    else:
+        if not rows:
+            print("(Нет строк)")
+        else:
+            print(format_table(columns, rows))
+
+
+def handle_tables(db: DatabaseConnection, args: argparse.Namespace) -> None:
+    rows = db.list_tables(include_system=args.include_system)
+    headers = ("schema", "table")
+    if not rows:
+        print("(Нет таблиц)")
+    else:
+        print(format_table(headers, rows))
+
+
+def handle_describe(db: DatabaseConnection, args: argparse.Namespace) -> None:
+    rows = db.describe_table(args.table)
+    headers = ("column", "type", "nullable", "default")
+    if not rows:
+        print("Таблица не найдена или не содержит колонок")
+    else:
+        print(format_table(headers, rows))
+
+
+def handle_export(db: DatabaseConnection, args: argparse.Namespace) -> None:
+    sql = read_sql(args.sql, args.file)
+    params = parse_params(args.params)
+    destination = Path(args.output)
+    db.export_to_csv(sql, destination, params=params)
+    print(f"Результат сохранён в {destination}")
+
+
+def handle_script(db: DatabaseConnection, args: argparse.Namespace) -> None:
+    sql = Path(args.path).read_text(encoding="utf-8")
+    db.execute_script(sql)
+    print("Скрипт выполнен успешно")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    try:
+        args = parser.parse_args(argv)
+        config = build_config(args)
+        with DatabaseConnection(config) as db:
+            if args.command == "query":
+                handle_query(db, args)
+            elif args.command == "tables":
+                handle_tables(db, args)
+            elif args.command == "describe":
+                handle_describe(db, args)
+            elif args.command == "export":
+                handle_export(db, args)
+            elif args.command == "script":
+                handle_script(db, args)
+            else:  # pragma: no cover - argparse ensures we don't reach here
+                parser.error(f"Неизвестная команда: {args.command}")
+    except Exception as exc:  # broad for CLI messaging
+        print(f"Ошибка: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/pgtool/config.py
+++ b/pgtool/config.py
@@ -1,0 +1,137 @@
+"""Configuration helpers for pgtool."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+import os
+
+try:  # Python >= 3.11
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - fallback for <3.11
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+@dataclass(slots=True)
+class DatabaseConfig:
+    """Parameters required to establish a PostgreSQL connection."""
+
+    host: Optional[str] = None
+    port: Optional[int] = None
+    user: Optional[str] = None
+    password: Optional[str] = None
+    database: Optional[str] = None
+    dsn: Optional[str] = None
+    options: Dict[str, str] = field(default_factory=dict)
+
+    def merged_with(self, other: "DatabaseConfig") -> "DatabaseConfig":
+        """Return a new config where ``other`` overrides ``self``."""
+
+        return DatabaseConfig(
+            host=other.host or self.host,
+            port=other.port or self.port,
+            user=other.user or self.user,
+            password=other.password or self.password,
+            database=other.database or self.database,
+            dsn=other.dsn or self.dsn,
+            options={**self.options, **other.options},
+        )
+
+    def to_connect_kwargs(self) -> Dict[str, object]:
+        """Translate the configuration into ``psycopg2.connect`` kwargs."""
+
+        if self.dsn:
+            return {"dsn": self.dsn}
+
+        kwargs: Dict[str, object] = {k: v for k, v in (
+            ("host", self.host),
+            ("port", self.port),
+            ("user", self.user),
+            ("password", self.password),
+            ("dbname", self.database),
+        ) if v is not None}
+        kwargs.update(self.options)
+        return kwargs
+
+    @classmethod
+    def from_mapping(cls, mapping: Dict[str, object]) -> "DatabaseConfig":
+        """Create a configuration instance from a raw mapping."""
+
+        options = mapping.get("options")
+        if not isinstance(options, dict):
+            options = {}
+
+        port = mapping.get("port")
+        if isinstance(port, str) and port.isdigit():
+            port = int(port)
+        elif isinstance(port, (float, int)):
+            port = int(port)
+        else:
+            port = None if port is None else int(port)
+
+        return cls(
+            host=mapping.get("host") or None,
+            port=port,
+            user=mapping.get("user") or None,
+            password=mapping.get("password") or None,
+            database=mapping.get("database") or None,
+            dsn=mapping.get("dsn") or None,
+            options={str(k): str(v) for k, v in options.items()},
+        )
+
+    @classmethod
+    def from_environment(cls, prefix: str = "PGTOOL_") -> "DatabaseConfig":
+        """Load configuration from environment variables."""
+
+        data: Dict[str, object] = {}
+        options: Dict[str, str] = {}
+        for key, value in os.environ.items():
+            if not key.startswith(prefix):
+                continue
+            raw_key = key[len(prefix):]
+            if raw_key.startswith("OPTION_"):
+                option_key = raw_key[len("OPTION_"):].lower()
+                options[option_key] = value
+            else:
+                data[raw_key.lower()] = value
+        if options:
+            data["options"] = options
+        return cls.from_mapping(data)
+
+
+DEFAULT_CONFIG_LOCATIONS = (
+    Path.cwd() / "pgtool.toml",
+    Path.home() / ".pgtool.toml",
+    Path.home() / ".config" / "pgtool" / "config.toml",
+)
+
+
+def load_config(path: Optional[str] = None) -> DatabaseConfig:
+    """Load configuration from a TOML file if it exists."""
+
+    candidate_paths: Iterable[Path]
+    if path:
+        candidate_paths = (Path(path),)
+    else:
+        candidate_paths = DEFAULT_CONFIG_LOCATIONS
+
+    for candidate in candidate_paths:
+        if candidate.is_file():
+            with candidate.open("rb") as fh:
+                data = tomllib.load(fh)
+            db_section = data.get("database") if isinstance(data, dict) else None
+            if not isinstance(db_section, dict):
+                raise ValueError(f"Configuration file {candidate} missing [database] section")
+            return DatabaseConfig.from_mapping(db_section)
+
+    return DatabaseConfig()
+
+
+def merge_configs(configs: Iterable[DatabaseConfig]) -> DatabaseConfig:
+    """Merge a collection of configurations, later ones winning."""
+
+    merged = DatabaseConfig()
+    for config in configs:
+        merged = merged.merged_with(config)
+    return merged

--- a/pgtool/db.py
+++ b/pgtool/db.py
@@ -1,0 +1,128 @@
+"""Database utilities wrapping psycopg2."""
+
+from __future__ import annotations
+
+import csv
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterable, Iterator, Optional, Sequence, Tuple
+
+import psycopg2
+
+from .config import DatabaseConfig
+
+Row = Tuple[object, ...]
+
+
+class DatabaseConnection:
+    """A lightweight helper around a PostgreSQL connection."""
+
+    def __init__(self, config: DatabaseConfig) -> None:
+        self._config = config
+        self._connection: Optional[psycopg2.extensions.connection] = None
+
+    def connect(self) -> psycopg2.extensions.connection:
+        if self._connection is None:
+            kwargs = self._config.to_connect_kwargs()
+            self._connection = psycopg2.connect(**kwargs)
+        return self._connection
+
+    def close(self) -> None:
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
+
+    def __enter__(self) -> "DatabaseConnection":  # pragma: no cover - convenience wrapper
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - convenience wrapper
+        self.close()
+
+    @contextmanager
+    def cursor(self) -> Iterator[psycopg2.extensions.cursor]:
+        connection = self.connect()
+        cursor = connection.cursor()
+        try:
+            yield cursor
+        finally:
+            cursor.close()
+
+    def run_query(self, query: str, params: Optional[Sequence[object]] = None, fetch: bool = True) -> Tuple[Sequence[str], Sequence[Row]]:
+        """Execute a query and optionally fetch results."""
+
+        with self.cursor() as cursor:
+            cursor.execute(query, params)
+            if fetch and cursor.description:
+                columns = [col.name if hasattr(col, "name") else col[0] for col in cursor.description]
+                rows = cursor.fetchall()
+            else:
+                columns, rows = (), ()
+            if not fetch:
+                self.connect().commit()
+        return columns, rows
+
+    def list_tables(self, include_system: bool = False) -> Sequence[Row]:
+        """Return schema and table name for available tables."""
+
+        if include_system:
+            schema_filter = ""
+        else:
+            schema_filter = "AND table_schema NOT IN ('pg_catalog', 'information_schema')"
+
+        query = f"""
+        SELECT table_schema, table_name
+        FROM information_schema.tables
+        WHERE table_type = 'BASE TABLE'
+        {schema_filter}
+        ORDER BY table_schema, table_name
+        """
+        _, rows = self.run_query(query)
+        return rows
+
+    def describe_table(self, table: str) -> Sequence[Row]:
+        """Return column metadata for the provided table."""
+
+        query = """
+        SELECT column_name, data_type, is_nullable, column_default
+        FROM information_schema.columns
+        WHERE table_schema = split_part(%s, '.', 1)
+          AND table_name = split_part(%s, '.', 2)
+        ORDER BY ordinal_position
+        """
+        schema_table = table if "." in table else f"public.{table}"
+        _, rows = self.run_query(query, (schema_table, schema_table))
+        return rows
+
+    def export_to_csv(self, query: str, destination: Path, params: Optional[Sequence[object]] = None) -> Path:
+        """Execute a query and store results in ``destination`` as CSV."""
+
+        columns, rows = self.run_query(query, params=params, fetch=True)
+        if not columns:
+            raise ValueError("Query did not return any data to export")
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with destination.open("w", encoding="utf-8", newline="") as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow(columns)
+            writer.writerows(rows)
+        return destination
+
+    def execute_script(self, sql: str) -> None:
+        """Execute a script with potentially multiple statements."""
+
+        with self.cursor() as cursor:
+            cursor.execute(sql)
+        self.connect().commit()
+
+    def iter_query(self, query: str, params: Optional[Sequence[object]] = None, chunk_size: int = 1000) -> Iterable[Row]:
+        """Iterate lazily over query results in batches."""
+
+        with self.cursor() as cursor:
+            cursor.execute(query, params)
+            while True:
+                chunk = cursor.fetchmany(chunk_size)
+                if not chunk:
+                    break
+                for row in chunk:
+                    yield row

--- a/pgtool/render.py
+++ b/pgtool/render.py
@@ -1,0 +1,36 @@
+"""Helpers for rendering query results in a table format."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+
+def stringify(value: object) -> str:
+    if value is None:
+        return "∅"
+    return str(value)
+
+
+def format_table(headers: Sequence[str], rows: Iterable[Sequence[object]]) -> str:
+    """Return a formatted table for CLI output."""
+
+    rows = [tuple(stringify(value) for value in row) for row in rows]
+    headers = tuple(stringify(header) for header in headers)
+
+    if not headers:
+        return "(No rows)"
+
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+
+    def format_row(row: Sequence[str]) -> str:
+        cells = [cell.ljust(widths[idx]) for idx, cell in enumerate(row)]
+        return " | ".join(cells)
+
+    header_line = format_row(headers)
+    separator = "-+-".join("-" * width for width in widths)
+    body_lines = [format_row(row) for row in rows]
+
+    return "\n".join([header_line, separator, *body_lines]) if body_lines else "\n".join([header_line, separator, "(No rows)"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "pgtool"
+version = "0.1.0"
+description = "Command-line utility for convenient PostgreSQL workflows"
+authors = [
+    {name = "Auto Generated"}
+]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "psycopg2-binary>=2.9",
+]
+
+[project.scripts]
+pgtool = "pgtool.cli:main"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add a `pgtool` package with CLI commands for querying PostgreSQL, inspecting tables, exporting CSV, and running scripts
- implement configuration loading from TOML files, environment variables, and CLI overrides
- document installation and usage and add packaging metadata plus ignore compiled files

## Testing
- python -m compileall pgtool

------
https://chatgpt.com/codex/tasks/task_e_68cfa1cffd788324a85b930bebd95f6e