### PR TITLE
Add registration flow with glitch results page

### DIFF
--- a/glitch.html
+++ b/glitch.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Система не отвечает</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles/glitch.css" />
+  </head>
+  <body>
+    <div class="glitch-wrapper">
+      <div class="glitch-title" data-text="Ошибка 503">Ошибка 503</div>
+      <p class="glitch-subtitle">
+        Система перегружена. Пожалуйста, не покидайте страницу.
+      </p>
+      <div class="entries" id="entries"></div>
+      <p class="glitch-footer">перезагрузка ядра...////</p>
+    </div>
+    <script src="scripts/glitch.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Регистрация</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <main class="hero">
+      <div class="hero__content">
+        <header class="hero__header">
+          <h1>Будущее начинается здесь</h1>
+          <p>
+            Присоединяйтесь к закрытому сообществу и узнавайте о новых
+            возможностях раньше всех.
+          </p>
+        </header>
+        <form class="hero__form" id="registration-form" novalidate>
+          <label class="input-group">
+            <span>ФИО</span>
+            <input
+              type="text"
+              name="fullName"
+              id="fullName"
+              placeholder="Иванов Иван Иванович"
+              required
+              autocomplete="name"
+            />
+          </label>
+          <label class="input-group">
+            <span>Номер телефона</span>
+            <input
+              type="tel"
+              name="phone"
+              id="phone"
+              placeholder="+7 (___) ___-__-__"
+              required
+              pattern="^\+7\s?\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{2}[\s-]?\d{2}$"
+              autocomplete="tel"
+            />
+          </label>
+          <button type="submit" class="hero__submit">Регистрация</button>
+          <p class="hero__agreement">
+            Нажимая на кнопку, вы соглашаетесь с обработкой персональных данных.
+          </p>
+        </form>
+      </div>
+      <div class="hero__visual">
+        <div class="glass-card">
+          <h2>Экосистема</h2>
+          <p>Кураторство, комьюнити, поддержка 24/7</p>
+        </div>
+        <div class="glow"></div>
+      </div>
+    </main>
+    <script src="scripts/register.js"></script>
+  </body>
+</html>

--- a/scripts/glitch.js
+++ b/scripts/glitch.js
@@ -1,0 +1,51 @@
+const container = document.getElementById("entries");
+
+const formatDate = (iso) => {
+  const date = new Date(iso);
+  return new Intl.DateTimeFormat("ru-RU", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(date);
+};
+
+const renderEntries = () => {
+  if (!container) return;
+  const entries = JSON.parse(localStorage.getItem("registrations") || "[]");
+  if (!entries.length) {
+    container.innerHTML =
+      '<p class="entry-empty">данные не получены. ожидание сигнала...</p>';
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+
+  entries.forEach((entry) => {
+    const card = document.createElement("article");
+    card.className = "entry-card";
+
+    const name = document.createElement("h3");
+    name.className = "entry-name";
+    name.textContent = entry.fullName;
+
+    const phone = document.createElement("p");
+    phone.className = "entry-phone";
+    phone.textContent = entry.phone;
+
+    const time = document.createElement("p");
+    time.className = "entry-time";
+    time.textContent = formatDate(entry.submittedAt);
+
+    card.append(name, phone, time);
+    fragment.appendChild(card);
+  });
+
+  container.innerHTML = "";
+  container.appendChild(fragment);
+};
+
+renderEntries();
+
+setInterval(() => {
+  container?.classList.toggle("glitch");
+}, 1200);

--- a/scripts/register.js
+++ b/scripts/register.js
@@ -1,0 +1,64 @@
+const form = document.getElementById("registration-form");
+const fullNameInput = document.getElementById("fullName");
+const phoneInput = document.getElementById("phone");
+
+const normalizePhone = (value) => {
+  const digits = value.replace(/\D/g, "");
+  if (!digits.startsWith("7")) {
+    return "+7" + digits.replace(/^\d/, "");
+  }
+  return "+" + digits;
+};
+
+const saveEntry = (entry) => {
+  const key = "registrations";
+  const existing = JSON.parse(localStorage.getItem(key) || "[]");
+  existing.unshift(entry);
+  localStorage.setItem(key, JSON.stringify(existing));
+};
+
+form?.addEventListener("submit", (event) => {
+  event.preventDefault();
+
+  const fullName = fullNameInput.value.trim();
+  const phone = normalizePhone(phoneInput.value.trim());
+
+  if (!fullName || !phone) {
+    form.classList.add("shake");
+    setTimeout(() => form.classList.remove("shake"), 600);
+    return;
+  }
+
+  saveEntry({
+    fullName,
+    phone,
+    submittedAt: new Date().toISOString(),
+  });
+
+  window.location.href = "glitch.html";
+});
+
+phoneInput?.addEventListener("input", () => {
+  const digits = phoneInput.value.replace(/\D/g, "");
+  const maxDigits = 11;
+  const trimmed = digits.slice(0, maxDigits);
+
+  let formatted = "+7";
+  if (trimmed.length > 1) {
+    formatted += ` (${trimmed.slice(1, 4)}`;
+  }
+  if (trimmed.length >= 4) {
+    formatted += ")";
+  }
+  if (trimmed.length >= 4) {
+    formatted += ` ${trimmed.slice(4, 7)}`;
+  }
+  if (trimmed.length >= 7) {
+    formatted += `-${trimmed.slice(7, 9)}`;
+  }
+  if (trimmed.length >= 9) {
+    formatted += `-${trimmed.slice(9, 11)}`;
+  }
+
+  phoneInput.value = formatted;
+});

--- a/styles/glitch.css
+++ b/styles/glitch.css
@@ -1,0 +1,196 @@
+:root {
+  font-family: "JetBrains Mono", monospace;
+  background: #050404;
+  color: #24ff8c;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: repeating-linear-gradient(
+      0deg,
+      rgba(0, 0, 0, 0.95) 0px,
+      rgba(0, 0, 0, 0.95) 2px,
+      rgba(10, 10, 10, 0.8) 3px,
+      rgba(20, 20, 20, 0.8) 4px
+    ),
+    radial-gradient(circle at 10% 20%, rgba(255, 0, 102, 0.15), transparent 35%),
+    radial-gradient(circle at 90% 80%, rgba(0, 255, 210, 0.12), transparent 35%),
+    #020202;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  color: inherit;
+}
+
+.glitch-wrapper {
+  width: min(960px, 100%);
+  border: 2px dashed rgba(36, 255, 140, 0.45);
+  padding: 32px;
+  background: rgba(0, 0, 0, 0.75);
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 0 0 4px rgba(255, 0, 0, 0.2);
+  transform: rotate(-1.5deg) skewX(-2deg);
+}
+
+.glitch-wrapper::before,
+.glitch-wrapper::after {
+  content: "";
+  position: absolute;
+  inset: -120px;
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(255, 0, 0, 0.2) 0,
+    rgba(255, 0, 0, 0.2) 2px,
+    rgba(0, 255, 255, 0.2) 3px,
+    rgba(0, 255, 255, 0.2) 5px
+  );
+  mix-blend-mode: screen;
+  animation: scan 4s linear infinite;
+  opacity: 0.4;
+}
+
+.glitch-wrapper::after {
+  animation-duration: 6s;
+  opacity: 0.25;
+}
+
+@keyframes scan {
+  0% {
+    transform: translateY(-10%);
+  }
+  100% {
+    transform: translateY(10%);
+  }
+}
+
+.glitch-title {
+  font-size: clamp(32px, 6vw, 64px);
+  margin: 0 0 8px;
+  position: relative;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.glitch-title::before,
+.glitch-title::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  mix-blend-mode: difference;
+}
+
+.glitch-title::before {
+  color: #ff005d;
+  transform: translate(-4px, -2px);
+}
+
+.glitch-title::after {
+  color: #0ff;
+  transform: translate(3px, 3px);
+}
+
+.glitch-subtitle {
+  margin: 0 0 24px;
+  color: rgba(255, 255, 255, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 13px;
+}
+
+.entries {
+  display: grid;
+  gap: 16px;
+  position: relative;
+  isolation: isolate;
+  margin-bottom: 24px;
+}
+
+.entries.glitch {
+  filter: hue-rotate(-40deg) contrast(1.4);
+}
+
+.entry-empty {
+  margin: 0;
+  padding: 24px 20px;
+  background: rgba(255, 0, 93, 0.1);
+  border: 1px dashed rgba(255, 0, 93, 0.6);
+  color: rgba(255, 255, 255, 0.65);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 12px;
+}
+
+.entry-card {
+  padding: 16px 20px;
+  background: rgba(12, 12, 12, 0.85);
+  border-left: 4px solid #ff005d;
+  border-right: 4px solid rgba(0, 255, 255, 0.5);
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6);
+  transform: rotate(-2deg);
+}
+
+.entry-card:nth-child(odd) {
+  transform: rotate(-1.8deg);
+}
+
+.entry-card:nth-child(even) {
+  transform: rotate(2deg);
+}
+
+.entry-card::before {
+  content: "////";
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  color: rgba(255, 255, 255, 0.25);
+  font-size: 12px;
+}
+
+.entry-name {
+  margin: 0;
+  font-size: 18px;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.entry-phone {
+  margin: 4px 0 0;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 14px;
+  letter-spacing: 0.08em;
+}
+
+.entry-time {
+  margin: 6px 0 0;
+  color: rgba(255, 255, 255, 0.35);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.glitch-footer {
+  margin: 0;
+  color: rgba(36, 255, 140, 0.6);
+  font-size: 12px;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 640px) {
+  .glitch-wrapper {
+    padding: 24px 16px;
+    transform: none;
+  }
+
+  .entries {
+    gap: 12px;
+  }
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,187 @@
+:root {
+  color-scheme: dark;
+  font-family: "Manrope", "Segoe UI", sans-serif;
+  background: #06050f;
+  color: #f6f7fb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, #5f4af9, transparent 55%),
+    radial-gradient(circle at 80% 20%, #25c6f9, transparent 55%),
+    radial-gradient(circle at 50% 80%, #4b2af7, transparent 55%),
+    #06050f;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 16px;
+}
+
+.hero {
+  width: min(960px, 100%);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 48px;
+  backdrop-filter: blur(24px);
+  background: rgba(10, 11, 29, 0.55);
+  border-radius: 32px;
+  padding: 48px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 80px rgba(22, 15, 64, 0.65);
+}
+
+.hero__header h1 {
+  font-size: clamp(32px, 5vw, 56px);
+  margin: 0 0 16px;
+}
+
+.hero__header p {
+  margin: 0 0 32px;
+  max-width: 420px;
+  color: rgba(246, 247, 251, 0.75);
+  line-height: 1.6;
+}
+
+.hero__form {
+  display: grid;
+  gap: 16px;
+}
+
+.hero__form.shake,
+.hero__form.shake * {
+  animation: shake 0.4s linear;
+}
+
+.input-group {
+  display: grid;
+  gap: 8px;
+}
+
+.input-group span {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 13px;
+  color: rgba(246, 247, 251, 0.6);
+}
+
+.input-group input {
+  width: 100%;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(9, 9, 22, 0.8);
+  padding: 16px 20px;
+  font-size: 16px;
+  color: inherit;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.input-group input:focus {
+  outline: none;
+  border-color: rgba(95, 74, 249, 0.8);
+  transform: translateY(-2px);
+}
+
+.hero__submit {
+  margin-top: 8px;
+  padding: 16px 20px;
+  border-radius: 18px;
+  border: none;
+  background: linear-gradient(135deg, #5f4af9, #25c6f9);
+  color: #06050f;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero__submit:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 40px rgba(95, 74, 249, 0.4);
+}
+
+.hero__agreement {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(246, 247, 251, 0.5);
+}
+
+.hero__visual {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.glass-card {
+  padding: 32px;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  backdrop-filter: blur(24px);
+  max-width: 280px;
+  text-align: left;
+  line-height: 1.5;
+  position: relative;
+  z-index: 1;
+}
+
+.glass-card h2 {
+  margin: 0 0 12px;
+  font-size: 22px;
+}
+
+.glass-card p {
+  margin: 0;
+  color: rgba(246, 247, 251, 0.7);
+}
+
+.glow {
+  position: absolute;
+  width: 220px;
+  height: 220px;
+  background: radial-gradient(circle, rgba(95, 74, 249, 0.65), transparent 65%);
+  filter: blur(0px);
+  transform: translate(80px, 20px);
+  animation: pulse 6s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: translate(80px, 20px) scale(1);
+    opacity: 0.8;
+  }
+  50% {
+    transform: translate(60px, 0) scale(1.2);
+    opacity: 0.4;
+  }
+}
+
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-6px);
+  }
+  75% {
+    transform: translateX(6px);
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 32px 16px;
+  }
+
+  .hero {
+    padding: 32px 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- create a modern landing page with FIO and +7 phone registration form
- store submissions in localStorage and redirect to a glitch-styled results page
- display all collected entries on the broken-looking page with newest submission first

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68cfa307742c8324b10b355f32d0ead7