### PR TITLE
Create registration landing and glitchy submissions page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Регистрация</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body class="landing">
+  <div class="landing__backdrop"></div>
+  <main class="landing__container">
+    <section class="landing__card">
+      <h1 class="landing__title">Присоединяйтесь к цифровому будущему</h1>
+      <p class="landing__subtitle">Оставьте ФИО и номер телефона, чтобы мы связались с вами. Мы перезвоним в течение 24 часов.</p>
+      <form id="registration-form" class="form">
+        <label class="form__label" for="fullName">ФИО</label>
+        <input class="form__input" type="text" id="fullName" name="fullName" placeholder="Иванов Иван Иванович" autocomplete="name" required />
+
+        <label class="form__label" for="phone">Телефон</label>
+        <div class="form__phone-wrapper">
+          <span class="form__prefix">+7</span>
+          <input class="form__input form__input--phone" type="tel" id="phone" name="phone" inputmode="numeric" pattern="\\d{10}" maxlength="10" placeholder="9991234567" required />
+        </div>
+
+        <button class="form__submit" type="submit">Зарегистрироваться</button>
+      </form>
+    </section>
+  </main>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('registration-form');
+  if (!form) return;
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const fullName = document.getElementById('fullName').value.trim();
+    const phoneInput = document.getElementById('phone');
+    const phoneRaw = phoneInput.value.replace(/\D/g, '');
+
+    if (!fullName) {
+      alert('Пожалуйста, укажите ФИО.');
+      return;
+    }
+
+    if (phoneRaw.length !== 10) {
+      alert('Введите 10 цифр после +7.');
+      phoneInput.focus();
+      return;
+    }
+
+    const stored = JSON.parse(localStorage.getItem('registrations') || '[]');
+    stored.push({
+      fullName,
+      phone: `+7${phoneRaw}`,
+      submittedAt: Date.now(),
+    });
+
+    localStorage.setItem('registrations', JSON.stringify(stored));
+    window.location.href = 'submissions.html';
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,162 @@
+:root {
+  --bg-gradient: linear-gradient(135deg, #1f2251 0%, #3c3ca4 50%, #8b5cf6 100%);
+  --card-bg: rgba(17, 17, 44, 0.72);
+  --card-border: rgba(255, 255, 255, 0.15);
+  --text-primary: #fdfdfd;
+  --text-secondary: rgba(255, 255, 255, 0.75);
+  --accent: #f59e0b;
+  --input-bg: rgba(255, 255, 255, 0.05);
+  --input-border: rgba(255, 255, 255, 0.2);
+  --input-focus: rgba(245, 158, 11, 0.4);
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Montserrat', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--bg-gradient);
+  color: var(--text-primary);
+  min-height: 100vh;
+}
+
+.landing {
+  position: relative;
+  overflow: hidden;
+}
+
+.landing__backdrop {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 10% 20%, rgba(245, 158, 11, 0.25), transparent 55%),
+    radial-gradient(circle at 90% 10%, rgba(56, 189, 248, 0.2), transparent 50%),
+    radial-gradient(circle at 40% 80%, rgba(168, 85, 247, 0.25), transparent 60%);
+  filter: blur(60px);
+  z-index: 0;
+}
+
+.landing__container {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+.landing__card {
+  width: min(480px, 100%);
+  backdrop-filter: blur(30px);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 25px 60px rgba(15, 15, 35, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.landing__title {
+  margin: 0;
+  font-size: clamp(1.8rem, 2.8vw, 2.6rem);
+  font-weight: 700;
+}
+
+.landing__subtitle {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form__label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.form__input {
+  width: 100%;
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--input-border);
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.form__input::placeholder {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.form__input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px var(--input-focus);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.form__phone-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.form__prefix {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  border: 1px solid var(--input-border);
+  background: rgba(255, 255, 255, 0.08);
+  font-weight: 600;
+}
+
+.form__input--phone {
+  flex: 1;
+}
+
+.form__submit {
+  margin-top: 0.5rem;
+  padding: 1rem 1.2rem;
+  border-radius: 14px;
+  border: none;
+  background: linear-gradient(90deg, #f97316 0%, #facc15 100%);
+  color: #11112c;
+  font-weight: 700;
+  font-size: 1.05rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form__submit:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 45px rgba(250, 204, 21, 0.35);
+}
+
+@media (max-width: 540px) {
+  .landing__card {
+    padding: 2rem;
+  }
+
+  .form__phone-wrapper {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .form__prefix {
+    justify-content: flex-start;
+  }
+}

--- a/submissions.css
+++ b/submissions.css
@@ -1,0 +1,180 @@
+body {
+  margin: 0;
+  font-family: 'Courier New', monospace;
+  background: #0f0f0f;
+  color: #f7f7f7;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+}
+
+.broken__header {
+  padding: 1.5rem 2rem 0.5rem;
+  text-align: center;
+  position: relative;
+  background: repeating-linear-gradient(45deg, #0f0f0f, #0f0f0f 10px, #111 10px, #111 20px);
+  color: #ff5f5f;
+  text-shadow: 0 0 10px rgba(255, 95, 95, 0.8);
+  transform: rotate(-0.7deg);
+}
+
+.broken__header h1 {
+  margin: 0;
+  font-size: 2.2rem;
+}
+
+.broken__header p {
+  margin: 0.5rem 0 0;
+  color: #f7f7f7;
+  font-style: italic;
+}
+
+.broken__content {
+  flex: 1;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  padding: 3rem 1rem 2rem;
+}
+
+.broken__panel {
+  position: relative;
+  width: min(780px, 100%);
+  border: 3px dashed #ff5f5f;
+  transform: skew(-1deg, -1deg) rotate(1.2deg);
+  overflow: hidden;
+  background: #050505;
+  box-shadow: inset 0 0 30px rgba(255, 95, 95, 0.2), 0 20px 60px rgba(0, 0, 0, 0.6);
+}
+
+.broken__noise {
+  pointer-events: none;
+  position: absolute;
+  inset: -100%;
+  background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160"%3E%3Cfilter id="n" x="0" y="0" width="1" height="1"%3E%3CfeTurbulence type="fractalNoise" baseFrequency="1.2" numOctaves="3" stitchTiles="stitch"/%3E%3C/filter%3E%3Crect width="160" height="160" filter="url(%23n)" opacity="0.25"/%3E%3C/svg%3E');
+  animation: noise 0.4s steps(4) infinite;
+  mix-blend-mode: screen;
+  opacity: 0.4;
+}
+
+@keyframes noise {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  25% {
+    transform: translate3d(-10px, 5px, 0);
+  }
+  50% {
+    transform: translate3d(7px, -3px, 0);
+  }
+  75% {
+    transform: translate3d(-4px, -6px, 0);
+  }
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+.broken__frame {
+  position: relative;
+  padding: 2rem 1.5rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  z-index: 1;
+}
+
+.broken__frame h2 {
+  margin: 0;
+  font-size: 1.7rem;
+  letter-spacing: 2px;
+  color: #f0f0f0;
+  text-transform: uppercase;
+}
+
+.broken__entries {
+  display: grid;
+  gap: 1rem;
+  max-height: clamp(220px, 60vh, 480px);
+  overflow-y: auto;
+  padding-right: 0.5rem;
+  filter: hue-rotate(-35deg) saturate(1.5);
+}
+
+.broken__entry {
+  background: rgba(255, 255, 255, 0.05);
+  border-left: 6px solid #ff5f5f;
+  padding: 1rem 1.25rem;
+  transform: rotate(calc((var(--i, 0) - 2) * 0.8deg));
+  box-shadow: 0 12px 35px rgba(255, 95, 95, 0.1);
+  position: relative;
+  overflow: hidden;
+}
+
+.broken__entry::before {
+  content: '###';
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  font-size: 0.85rem;
+  color: rgba(255, 95, 95, 0.45);
+}
+
+.broken__entry-name {
+  margin: 0 0 0.25rem;
+  font-size: 1.1rem;
+  font-weight: bold;
+}
+
+.broken__entry-phone {
+  margin: 0;
+  font-size: 1rem;
+  color: #ffcf99;
+}
+
+.broken__entry-date {
+  margin: 0.35rem 0 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.broken__footer {
+  padding: 1rem 2rem 2rem;
+  text-align: center;
+  transform: rotate(0.6deg);
+}
+
+.broken__footer a {
+  color: #ff5f5f;
+  text-decoration: none;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  border-bottom: 2px dotted currentColor;
+}
+
+@media (max-width: 640px) {
+  .broken__header {
+    transform: none;
+  }
+
+  .broken__panel {
+    transform: none;
+  }
+
+  .broken__footer {
+    transform: none;
+  }
+}
+
+.broken__empty {
+  margin: 0;
+  padding: 2rem;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.05);
+  border: 2px dotted #ff5f5f;
+  transform: rotate(-1.5deg);
+}

--- a/submissions.html
+++ b/submissions.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Реестр регистраций</title>
+  <link rel="stylesheet" href="submissions.css" />
+</head>
+<body class="broken">
+  <header class="broken__header">
+    <h1>Форма... кажется, сломалась?</h1>
+    <p>Но все заявки все ещё здесь. Возможно.</p>
+  </header>
+  <main class="broken__content">
+    <section class="broken__panel">
+      <div class="broken__noise"></div>
+      <div class="broken__frame">
+        <h2>Последние регистрации</h2>
+        <div id="entries" class="broken__entries" aria-live="polite"></div>
+      </div>
+    </section>
+  </main>
+  <footer class="broken__footer">
+    <a href="index.html">&larr; Вернуться к форме</a>
+  </footer>
+  <script src="submissions.js"></script>
+</body>
+</html>

--- a/submissions.js
+++ b/submissions.js
@@ -1,0 +1,35 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const entriesContainer = document.getElementById('entries');
+  if (!entriesContainer) return;
+
+  const stored = JSON.parse(localStorage.getItem('registrations') || '[]');
+  if (!stored.length) {
+    entriesContainer.innerHTML = `
+      <p class="broken__empty">Пока никто не оставил заявку. Возможно, сервер снова завис...</p>
+    `;
+    return;
+  }
+
+  stored
+    .sort((a, b) => b.submittedAt - a.submittedAt)
+    .forEach((entry, index) => {
+      const card = document.createElement('article');
+      card.className = 'broken__entry';
+      card.style.setProperty('--i', index);
+
+      const name = document.createElement('h3');
+      name.className = 'broken__entry-name';
+      name.textContent = entry.fullName;
+
+      const phone = document.createElement('p');
+      phone.className = 'broken__entry-phone';
+      phone.textContent = entry.phone;
+
+      const date = document.createElement('p');
+      date.className = 'broken__entry-date';
+      date.textContent = new Date(entry.submittedAt).toLocaleString('ru-RU');
+
+      card.append(name, phone, date);
+      entriesContainer.appendChild(card);
+    });
+});


### PR DESCRIPTION
## Summary
- add a modern landing page with a registration form for ФИО и телефон
- store submissions in localStorage and redirect to a glitchy list of registrations
- design the submissions view to look intentionally broken while keeping the newest entry on top

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cfa307742c8324b10b355f32d0ead7